### PR TITLE
Edit json generation

### DIFF
--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -108,6 +108,8 @@ class OpenApiGenerator {
       removeResponse: model,
       removeMultiResponse: modelList,
       filterParameter: model,
+      resolverParameter: '',
+      properties: `${model}_properties`,
       sortParameter: ''
     };
     if (typeof this.config.defaults.getOperationsRefs === 'function') {

--- a/lib/v3/generator.js
+++ b/lib/v3/generator.js
@@ -1,6 +1,18 @@
 const AbstractApiGenerator = require('../openapi');
 const utils = require('../utils');
 
+function apiKeySecurity () {
+  return {
+    description: "Authorization using an API Key",
+    in: "header",
+    name: "x-api-key",
+    style: "form",
+    schema: {
+      type: "string"
+    }
+  }
+}
+
 function addDefinitionToSchemas (schemas, definition, model, modelName) {
   schemas[model] = definition;
   schemas[`${model}_list`] = {
@@ -10,15 +22,63 @@ function addDefinitionToSchemas (schemas, definition, model, modelName) {
   };
 }
 
+function joinParameter(refs) {
+  if(refs.resolverParameter) {
+    return {
+      description: 'Tables to join in query. Use SHIFT to select mulitple',
+      in: 'query',
+      name: '$join',
+      style: 'form',
+      schema: {
+        type: 'array',
+        items: {
+          $ref: `#/components/schemas/${refs.resolverParameter}`
+        }
+      }
+    }
+  } else { return {
+    description: 'Tables to join in query. This operation doesn\'t have any defined resolvers',
+    in: 'query',
+    name: '$join',
+
+  }}
+}
+
 function filterParameter (refs) {
-  return {
-    description: 'Query parameters to filter',
+  return [{
+    description: 'Query parameters to filter. An example of this parameter: userId[$gt]=1000',
     in: 'query',
     name: 'filter',
     style: 'form',
     explode: true,
-    schema: { $ref: `#/components/schemas/${refs.filterParameter}` }
-  };
+    schema: {
+      type: 'array',
+      items: {
+        enum: [
+          '$gt',
+          '$gte',
+          '$lt',
+          '$lte',
+          '$ne',
+          '$in',
+          '$nin'
+        ]
+      }
+    }
+  },
+  {
+    description: 'Filter results to only selected parameters. An example of this parameter: $select[0]=userId',
+    in: 'query',
+    name: '$select[0]',
+    style: 'form',
+    explode: true,
+    schema: {
+      type: 'array',
+      items: {
+        $ref: `#/components/schemas/${refs.properties}`
+      }
+    }
+  }];
 }
 
 function jsonSchemaRef (ref) {
@@ -101,13 +161,18 @@ class OpenApiV3Generator extends AbstractApiGenerator {
             }, {
               description: 'Property to sort results',
               in: 'query',
-              name: '$sort',
+              name: '$sort[parameter]',
               style: 'deepObject',
               schema: {
-                ...(refs.sortParameter ? { $ref: `#/components/schemas/${refs.sortParameter}` } : { type: 'object' })
+                type: "integer",
+                enum: [
+                  1, -1
+                ]
               }
             },
-            filterParameter(refs)
+            joinParameter(refs),
+            ...filterParameter(refs),
+            apiKeySecurity(),
           ],
           responses: {
             200: {
@@ -252,7 +317,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Updates multiple resources queried by given filters.',
-          parameters: [filterParameter(refs)],
+          parameters: [...filterParameter(refs)],
           requestBody: {
             required: true,
             content: jsonSchemaRef(refs.patchMultiRequest)
@@ -299,7 +364,7 @@ class OpenApiV3Generator extends AbstractApiGenerator {
         return {
           tags,
           description: 'Removes multiple resources queried by given filters.',
-          parameters: [filterParameter(refs)],
+          parameters: [...filterParameter(refs)],
           responses: {
             200: {
               description: 'success',

--- a/lib/v3/generator.js
+++ b/lib/v3/generator.js
@@ -1,18 +1,6 @@
 const AbstractApiGenerator = require('../openapi');
 const utils = require('../utils');
 
-function apiKeySecurity () {
-  return {
-    description: "Authorization using an API Key",
-    in: "header",
-    name: "x-api-key",
-    style: "form",
-    schema: {
-      type: "string"
-    }
-  }
-}
-
 function addDefinitionToSchemas (schemas, definition, model, modelName) {
   schemas[model] = definition;
   schemas[`${model}_list`] = {
@@ -172,7 +160,6 @@ class OpenApiV3Generator extends AbstractApiGenerator {
             },
             joinParameter(refs),
             ...filterParameter(refs),
-            apiKeySecurity(),
           ],
           responses: {
             200: {


### PR DESCRIPTION
### Summary
This PR edits the generation for the swagger json generation. 

The generator will now accept a schema for an object's resolvers so that the new $join parameter will allow the user to see the available $join table options. 

The generator also accepts a schema for an object's properties so that the user can see the options for the new $select property.

The generator will also now show the user available operations that can be used to filter the query.


This is what the doc page looked like before these generation changes were made:
![image](https://user-images.githubusercontent.com/98903511/205305134-6ead1333-51fc-4d11-9901-e365fed7f23e.png)

This is what the doc page will look like after these changes:
![image](https://user-images.githubusercontent.com/98903511/205306923-b6f20dc0-f309-4a06-a696-d1431d4fc0cc.png)
